### PR TITLE
adds openssf score

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,7 @@ dist
 npm-shrinkwrap.json
 package-lock.json
 yarn.lock
+
+.vscode/
+
+repoOSSF.json


### PR DESCRIPTION
Solves issue #63 by computing `openssf` score on each of the repos fetched by `repo-report` and writing the `Aggregate Score` into a `repoOSSF.JSON` file

Setup instructions for MacOS users:
```bash
brew install scorecard
```
```bash
cd repo-report
```
```bash
node ./bin/run
```

Note: This will take a solid 10-15 minutes, sit back and relax meanwhile 🙂 
CC: @ljharb 👋 