### PR TITLE
add --names option 

### DIFF
--- a/bin/repoArgs.js
+++ b/bin/repoArgs.js
@@ -13,6 +13,11 @@ module.exports = function repoArgs(yargs) {
 			],
 			describe: 'Focus repo types',
 		})
+		.option('names', {
+			default: false,
+			describe: 'Shows the list of repo names with their owner',
+			type: 'boolean',
+		})
 		.option('sort', {
 			alias: 's',
 			default: false,

--- a/src/commands/detail.js
+++ b/src/commands/detail.js
@@ -114,6 +114,13 @@ module.exports = async function detail(flags) {
 		repositories.sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
 	}
 
+	if (flags.names) {
+		repositories.forEach((repository) => {
+			console.log(repository.nameWithOwner);
+		});
+		return null;
+	}
+
 	// Generate output table
 	const table = generateDetailTable(metrics, repositories, {
 		actual: flags.actual,


### PR DESCRIPTION
solves #50, by adding the `--names` option.
```bash
.option('names', {
			alias: 'n',
			default: false,
			describe: 'Shows the list of repo names with their owner',
			type: 'boolean',
		})
```
On setting `true` it outputs the list of `repos-with-their owner` instead of the `repo-report` table.
will remove the alias if it's not required here, or can come up with a more meaningful name for the option

cc: @ljharb 