### PR TITLE
Issue 23 with only 2 flag "Extend sorting functionality"

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,10 @@ OR you can add it to a .env file in the project root:
 - Shows repo names alongside their owners
 
 10. ``-s, --sort``
-- Sorts alphabetically (It's sorted by last updated by default)
+- Sorts by "last updated date" by default; can be set to `name` or `created` instead.
+
+11. ``-desc``
+- Sorts descending instead of ascending.
 
 11. ``--cache``
 - Saves API request data in ``--cacheDir``.

--- a/bin/repoArgs.js
+++ b/bin/repoArgs.js
@@ -20,8 +20,14 @@ module.exports = function repoArgs(yargs) {
 		})
 		.option('sort', {
 			alias: 's',
+			choices: ['name', 'updated', 'created'],
+			default: 'updated',
+			describe: 'Sort repositories by field such as name, updated date, or created date.',
+			type: 'string',
+		})
+		.option('desc', {
 			default: false,
-			describe: 'Sort repos alphabetically, instead of by "last updated"',
+			describe: 'Sort descending, instead of ascending)',
 			type: 'boolean',
 		});
 };

--- a/src/commands/detail.js
+++ b/src/commands/detail.js
@@ -6,7 +6,7 @@ const {
 	printAPIPoints,
 	generateDetailTable,
 } = require('../utils');
-const getRepositories = require('../getRepositories');
+const { getRepositories } = require('../getRepositories');
 const loadingIndicator = require('../loadingIndicator');
 
 const getMetrics = require('../metrics');

--- a/src/commands/ls.js
+++ b/src/commands/ls.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const getRepositories = require('../getRepositories');
+const { getRepositories } = require('../getRepositories');
 const loadingIndicator = require('../loadingIndicator');
 
 module.exports = async function ls(flags) {

--- a/test/sortRepositoriesTest.js
+++ b/test/sortRepositoriesTest.js
@@ -1,0 +1,61 @@
+'use strict';
+
+const test = require('tape');
+const mockRepositoriesData = require('./fixtures/mockRepositoriesData.json');
+
+const getRepositories = () => mockRepositoriesData.data.viewer.repositories.nodes;
+
+const { sortRepositories } = require('../src/getRepositories');
+
+/** @return {ReturnType<typeof getRepositories>} */
+function cloneData() {
+	return JSON.parse(JSON.stringify(getRepositories()));
+}
+
+test('Sort by name ASC', (t) => {
+	const repos = cloneData();
+	const actual = sortRepositories(repos, { sort: 'name', desc: false });
+	const expected = [...cloneData()].sort((a, b) => a.name.localeCompare(b.name));
+	t.deepEqual(actual, expected, 'Repos should be sorted by name A → Z');
+	t.end();
+});
+
+test('Sort by name DESC', (t) => {
+	const repos = cloneData();
+	const actual = sortRepositories(repos, { sort: 'name', desc: true });
+	const expected = [...cloneData()].sort((a, b) => b.name.localeCompare(a.name));
+	t.deepEqual(actual, expected, 'Repos should be sorted by name Z → A');
+	t.end();
+});
+
+test('Sort by updatedDate DESC (default)', (t) => {
+	const repos = cloneData();
+	const actual = sortRepositories(repos, { sort: 'updatedDate', desc: false });
+	const expected = [...cloneData()].sort((a, b) => new Date(b.updatedAt) - new Date(a.updatedAt));
+	t.deepEqual(actual, expected, 'Repos should be sorted by updatedDate newest → oldest');
+	t.end();
+});
+
+test('Sort by updatedDate ASC', (t) => {
+	const repos = cloneData();
+	const actual = sortRepositories(repos, { sort: 'updatedDate', desc: true });
+	const expected = [...cloneData()].sort((a, b) => new Date(a.updatedAt) - new Date(b.updatedAt));
+	t.deepEqual(actual, expected, 'Repos should be sorted by updatedDate oldest → newest');
+	t.end();
+});
+
+test('Sort by createdDate DESC', (t) => {
+	const repos = cloneData();
+	const actual = sortRepositories(repos, { sort: 'createdDate', desc: false });
+	const expected = [...cloneData()].sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+	t.deepEqual(actual, expected, 'Repos should be sorted by createdDate newest → oldest');
+	t.end();
+});
+
+test('Sort by createdDate ASC', (t) => {
+	const repos = cloneData();
+	const actual = sortRepositories(repos, { sort: 'createdDate', desc: true });
+	const expected = [...cloneData()].sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
+	t.deepEqual(actual, expected, 'Repos should be sorted by createdDate oldest → newest');
+	t.end();
+});


### PR DESCRIPTION
Added Sorting functionality with only 2 flags.

Can be sorted by name, updated date, created date.

npx repo-report --sortBy name --reverse

npx repo-report -sb name
npx repo-report -sb name -r

npx repo-report -sb createdDate
npx repo-report -sb createdDate -r

npx repo-report -sb updatedDate
npx repo-report -sb updatedDate -r





Test passed.
<img width="1008" height="841" alt="image" src="https://github.com/user-attachments/assets/38820733-82c1-417b-87f9-730007a5e15b" />

