### PR TITLE
[New] add metric: RequireBranchesBeUpToDateBeforeMerging

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -31,7 +31,8 @@
     "RequiredBranchProtectionSourcePercentage": 100,
     "WebCommitSignoffRequired": false,
     "CodeOfConduct": [null, "Contributor Covenant"],
-    "RequireLastPushApproval": true
+    "RequireLastPushApproval": true,
+    "RequireBranchesBeUpToDateBeforeMerging": true
   },
   "overrides": [],
   "repositories": {

--- a/config/metrics.js
+++ b/config/metrics.js
@@ -193,4 +193,8 @@ module.exports = {
 		extract: (item) => !!getBPRules(item)?.requireLastPushApproval,
 		permissions: ['ADMIN', 'MAINTAIN'],
 	},
+	RequireBranchesBeUpToDateBeforeMerging: {
+		extract: (item) => !!getBPRules(item)?.requiresStrictStatusChecks,
+		permissions: ['ADMIN', 'MAINTAIN'],
+	},
 };

--- a/config/metrics.json
+++ b/config/metrics.json
@@ -99,7 +99,8 @@
 		},
 		"WebCommitSignoffRequired": { "type": ["boolean", "null"] },
 		"WikiEnabled": { "type": ["boolean", "null"] },
-		"RequireLastPushApproval": { "type": ["boolean", "null"] }
+		"RequireLastPushApproval": { "type": ["boolean", "null"] },
+		"RequireBranchesBeUpToDateBeforeMerging": { "type": ["boolean", "null"] }
 	},
 	"type": "object"
 }

--- a/src/getRepositories.js
+++ b/src/getRepositories.js
@@ -42,6 +42,7 @@ function generateQuery(endCursor, { f }, perPage = 20) {
 								requiresConversationResolution
 								restrictsPushes
 								requireLastPushApproval
+								requiresStrictStatusChecks
 								requiredStatusChecks {
 									app {
 										id

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -43,10 +43,12 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		'11.1% (1/9)',
 		'55.6% (5/9)',
 		'11.1% (1/9)',
+		'22.2% (2/9)',
 	],
 	[
 		'name/challenges-book\nname/responsive-design',
 		`${symbols.success}`,
+		`${symbols.error}`,
 		`${symbols.error}`,
 		`${symbols.error}`,
 		`${symbols.error}`,
@@ -59,14 +61,7 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		`${symbols.error}`,
 		`${symbols.success}`,
 		`${symbols.error}`,
-	],
-	[
-		'name/tc39-ci',
-		`${symbols.success}`,
-		`${symbols.success}`,
 		`${symbols.error}`,
-		`${symbols.error}`,
-		`${symbols.success}`,
 	],
 	[
 		'name/ecma262',
@@ -75,6 +70,16 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		`${symbols.success}`,
 		`${symbols.error}`,
 		`${symbols.error}`,
+		`${symbols.error}`,
+	],
+	[
+		'name/tc39-ci',
+		`${symbols.success}`,
+		`${symbols.success}`,
+		`${symbols.error}`,
+		`${symbols.error}`,
+		`${symbols.success}`,
+		`${symbols.success}`,
 	],
 	[
 		'name/agendas',
@@ -83,11 +88,19 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		`${symbols.error}`,
 		`${symbols.success}`,
 		`${symbols.error}`,
+		`${symbols.success}`,
 	],
 ], {
 	options: {
 		...expectedOptions,
-		head: ['Repository', 'Access\nCodeOfConduct', 'DefBranch', 'SecurityPolicyEnabled', 'RequiredBranchProtectionSourcePercentage', 'RequireLastPushApproval'],
+		head: [
+			'Repository',
+			'Access\nCodeOfConduct',
+			'DefBranch',
+			'SecurityPolicyEnabled',
+			'RequiredBranchProtectionSourcePercentage',
+			'RequireLastPushApproval',
+			'RequireBranchesBeUpToDateBeforeMerging'],
 	},
 }), Table.prototype);
 
@@ -100,6 +113,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'---',
 		'100',
 		'false',
+		'false',
 	],
 	[
 		'name/challenges-book',
@@ -108,6 +122,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'false',
 		'---',
 		'40',
+		'false',
 		'false',
 	],
 	[
@@ -118,6 +133,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'Contributor Covenant',
 		'0',
 		'false',
+		'false',
 	],
 	[
 		'name/media-upload-app',
@@ -126,6 +142,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'false',
 		'---',
 		'100',
+		'false',
 		'false',
 	],
 	[
@@ -136,6 +153,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'---',
 		'60',
 		'true',
+		'true',
 	],
 	[
 		'name/ecma262',
@@ -144,6 +162,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'true',
 		'Contributor Covenant',
 		'50',
+		'false',
 		'false',
 	],
 	[
@@ -154,11 +173,20 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'---',
 		'100',
 		'false',
+		'true',
 	],
 ], {
 	options: {
 		...expectedOptions,
-		head: ['Repository', 'Access', 'DefBranch', 'SecurityPolicyEnabled', 'CodeOfConduct', 'RequiredBranchProtectionSourcePercentage', 'RequireLastPushApproval'],
+		head: [
+			'Repository',
+			'Access',
+			'DefBranch',
+			'SecurityPolicyEnabled',
+			'CodeOfConduct',
+			'RequiredBranchProtectionSourcePercentage',
+			'RequireLastPushApproval',
+			'RequireBranchesBeUpToDateBeforeMerging'],
 	},
 }), Table.prototype);
 
@@ -171,6 +199,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.ignore} ---`,
 		`${symbols.error} 40`,
 		`${symbols.error} false`,
+		`${symbols.error} false`,
 	],
 	[
 		'name/responsive-design',
@@ -179,6 +208,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.error} false`,
 		`${symbols.success} Contributor Covenant`,
 		`${symbols.error} 0`,
+		`${symbols.error} false`,
 		`${symbols.error} false`,
 	],
 	[
@@ -189,6 +219,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.ignore} ---`,
 		`${symbols.success} 100`,
 		`${symbols.error} false`,
+		`${symbols.error} false`,
 	],
 	[
 		'name/media-upload-app',
@@ -197,6 +228,17 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.error} false`,
 		`${symbols.ignore} ---`,
 		`${symbols.success} 100`,
+		`${symbols.error} false`,
+		`${symbols.error} false`,
+	],
+	[
+		'name/ecma262',
+		`${symbols.success} ADMIN`,
+		`${symbols.success} main`,
+		`${symbols.success} true`,
+		`${symbols.success} Contributor Covenant`,
+		`${symbols.error} 50`,
+		`${symbols.error} false`,
 		`${symbols.error} false`,
 	],
 	[
@@ -207,15 +249,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.ignore} ---`,
 		`${symbols.error} 60`,
 		`${symbols.success} true`,
-	],
-	[
-		'name/ecma262',
-		`${symbols.success} ADMIN`,
-		`${symbols.success} main`,
 		`${symbols.success} true`,
-		`${symbols.success} Contributor Covenant`,
-		`${symbols.error} 50`,
-		`${symbols.error} false`,
 	],
 	[
 		'name/agendas',
@@ -225,11 +259,21 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.ignore} ---`,
 		`${symbols.success} 100`,
 		`${symbols.error} false`,
+		`${symbols.success} true`,
 	],
 ], {
 	options: {
 		...expectedOptions,
-		head: ['Repository', 'Access', 'DefBranch', 'SecurityPolicyEnabled', 'CodeOfConduct', 'RequiredBranchProtectionSourcePercentage', 'RequireLastPushApproval'],
+		head: [
+			'Repository',
+			'Access',
+			'DefBranch',
+			'SecurityPolicyEnabled',
+			'CodeOfConduct',
+			'RequiredBranchProtectionSourcePercentage',
+			'RequireLastPushApproval',
+			'RequireBranchesBeUpToDateBeforeMerging',
+		],
 	},
 }), Table.prototype);
 
@@ -258,6 +302,7 @@ const DetailTableColumns = [
 	'ReqCodeOwnerReviews',
 	'ReqConversationResolution',
 	'RequireLastPushApproval',
+	'RequireBranchesBeUpToDateBeforeMerging',
 ];
 
 const sortedRepositories = require('./sortedRepositories.json');

--- a/test/fixtures/metricConfig.json
+++ b/test/fixtures/metricConfig.json
@@ -12,6 +12,7 @@
 		"BlankIssuesEnabled": false,
 		"SecurityPolicyEnabled": true,
 		"RequireLastPushApproval": true,
+		"RequireBranchesBeUpToDateBeforeMerging": true,
 		"License": ["MIT License", null],
 		"MergeStrategies": {
 			"MERGE": true,

--- a/test/fixtures/mockRepositoriesData.json
+++ b/test/fixtures/mockRepositoriesData.json
@@ -137,7 +137,8 @@
 										"app": null
 									}
 								],
-								"requireLastPushApproval": true
+								"requireLastPushApproval": true,
+								"requiresStrictStatusChecks": true
 							}
 						},
 						"viewerPermission": "ADMIN",
@@ -176,9 +177,13 @@
 							"name": "---"
 						},
 						"defaultBranchRef": {
-							"name": "main"
+							"name": "main",
+							"branchProtectionRule": {
+							"requiresStrictStatusChecks": true
+						}
 						},
 						"viewerPermission": "ADMIN"
+
 					}
 				]
 			}

--- a/test/utils/generateDetailTable.js
+++ b/test/utils/generateDetailTable.js
@@ -13,7 +13,7 @@ const {
 
 const getMetrics = require('../../src/metrics');
 
-const metrics = getMetrics(['Repository', 'Access', 'DefBranch', 'isPrivate', 'SecurityPolicyEnabled', 'CodeOfConduct', 'RequiredBranchProtectionSourcePercentage', 'RequireLastPushApproval']);
+const metrics = getMetrics(['Repository', 'Access', 'DefBranch', 'isPrivate', 'SecurityPolicyEnabled', 'CodeOfConduct', 'RequiredBranchProtectionSourcePercentage', 'RequireLastPushApproval', 'RequireBranchesBeUpToDateBeforeMerging']);
 
 function compareTables(t, actual, expected, msg, invalid = false) {
 	const comparator = invalid ? 'notDeepEqual' : 'deepEqual';
@@ -32,6 +32,12 @@ function compareTables(t, actual, expected, msg, invalid = false) {
 				'table options are deepEqual',
 			);
 		}
+		const a = Array.prototype.slice.call(actual);
+		const b = Array.prototype.slice.call(expected);
+		for (let i = 0; i < a.length; i++) {
+			st[comparator](a[i], b[i], `row ${i} is ${invalid ? 'not ' : ''}deepEqual`);
+		}
+
 		st[comparator](
 			Array.prototype.slice.call(actual),
 			Array.prototype.slice.call(expected),


### PR DESCRIPTION
Added metric : "RequireBranchesBeUpToDateBeforeMerging"

If "Require branches to be up to date before merging" is not selected,
<img width="857" height="182" alt="image" src="https://github.com/user-attachments/assets/ad5a0d0d-a756-42a6-842c-3e5ab75eb82b" />

it show ❌.
<img width="1771" height="837" alt="image" src="https://github.com/user-attachments/assets/55e178e8-8590-4b03-8d95-b3bfa76b4b97" />
...................................................................................................................................................................................................................................................................

If "Require branches to be up to date before merging" is selected,
<img width="856" height="186" alt="image" src="https://github.com/user-attachments/assets/d26d0e8e-fc4b-40ee-8a20-4516092b41dc" />

it show ✅.
<img width="1687" height="837" alt="image" src="https://github.com/user-attachments/assets/47b7d9f1-e592-4e64-a53d-74fbb9fc9be5" />
