### PR TITLE
PrivateVulnerabilityReportingEnabled

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -10,6 +10,7 @@
     "AutoMergeAllowed": false,
     "BlankIssuesEnabled": false,
     "SecurityPolicyEnabled": true,
+    "PrivateVulnerabilityReportingEnabled": true,
     "License": ["MIT License", null],
     "MergeStrategies": {
       "MERGE": true,

--- a/config/metrics.js
+++ b/config/metrics.js
@@ -82,6 +82,11 @@ module.exports = {
 		extract: (item) => !!item.isSecurityPolicyEnabled,
 		permissions: ['ADMIN', 'MAINTAIN', 'WRITE'],
 	},
+	PrivateVulnerabilityReportingEnabled: {
+		compare: (item, config) => !!config === item.hasPrivateVulnerabilityReportingEnabled,
+		extract: (item) => !!item.hasPrivateVulnerabilityReportingEnabled,
+		permissions: ['ADMIN', 'MAINTAIN'],
+	},
 	License: {
 		compare: (item, config) => config?.includes(item.licenseInfo?.name || null),
 		extract: (item) => item.licenseInfo?.name || empty,

--- a/config/metrics.json
+++ b/config/metrics.json
@@ -71,6 +71,7 @@
 		"ReqCodeOwnerReviews": { "type": ["boolean", "null"] },
 		"ReqConversationResolution": { "type": ["boolean", "null"] },
 		"SecurityPolicyEnabled": { "type": ["boolean", "null"] },
+		"PrivateVulnerabilityReportingEnabled": { "type": ["boolean", "null"] },
 		"Subscription": {
 			"oneOf": [
 				{

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
 	"license": "MIT",
 	"dependencies": {
 		"@octokit/graphql": "^8.2.0",
+		"@octokit/request": "^10.0.3",
 		"cli-table": "^0.3.11",
 		"colors": "=1.4.0",
 		"dotenv": "^16.4.7",

--- a/src/utils.js
+++ b/src/utils.js
@@ -6,6 +6,7 @@
 
 const fs = require('fs');
 const { graphql } = require('@octokit/graphql');
+const { request } = require('@octokit/request');
 const Table = require('cli-table');
 const { minimatch } = require('minimatch');
 const colors = require('colors/safe');
@@ -107,6 +108,21 @@ const printAPIPoints = (points) => {
 	console.error(`API Points:
 \tused\t\t-\t${points.cost}
 \tremaining\t-\t${points.remaining}`);
+};
+
+const checkPrivateVulnerabilityReporting = async (owner, repo, token) => {
+	try {
+		const response = await request('GET /repos/{owner}/{repo}/private-vulnerability-reporting', {
+			headers: {
+				authorization: `token ${token}`,
+			},
+			owner,
+			repo,
+		});
+		return response.data.enabled;
+	} catch (error) {
+		return false;
+	}
 };
 
 const getRepositories = async (generateQuery, flags = {}, { filter = undefined, perPage = 20 } = {}) => {
@@ -364,6 +380,7 @@ const generateDetailTable = (metrics, rowData, {
 };
 
 module.exports = {
+	checkPrivateVulnerabilityReporting,
 	dumpCache,
 	generateDetailTable,
 	getDiffSymbol,

--- a/test/fixtures/metricConfig.json
+++ b/test/fixtures/metricConfig.json
@@ -11,6 +11,7 @@
 		"AutoMergeAllowed": false,
 		"BlankIssuesEnabled": false,
 		"SecurityPolicyEnabled": true,
+		"PrivateVulnerabilityReportingEnabled": true,
 		"License": ["MIT License", null],
 		"MergeStrategies": {
 			"MERGE": true,


### PR DESCRIPTION
-Added a new metric to track the GitHub private vulnerability reporting setting. 
-Extracts have Private Vulnerability Reporting Enabled from repository data 