### PR TITLE
[New] add metric: `SponsorshipsEnabled`

### DIFF
--- a/config/defaults.json
+++ b/config/defaults.json
@@ -33,7 +33,8 @@
     "WebCommitSignoffRequired": false,
     "CodeOfConduct": [null, "Contributor Covenant"],
     "RequireLastPushApproval": true,
-    "RequireBranchesBeUpToDateBeforeMerging": true
+    "RequireBranchesBeUpToDateBeforeMerging": true,
+    "SponsorshipsEnabled": true
   },
   "overrides": [],
   "repositories": {

--- a/config/metrics.js
+++ b/config/metrics.js
@@ -204,4 +204,8 @@ module.exports = {
 		extract: (item) => !!getBPRules(item)?.requiresStrictStatusChecks,
 		permissions: ['ADMIN', 'MAINTAIN'],
 	},
+	SponsorshipsEnabled: {
+		extract: (item) => !!item.hasSponsorshipsEnabled,
+		permissions: ['ADMIN', 'MAINTAIN'],
+	},
 };

--- a/config/metrics.json
+++ b/config/metrics.json
@@ -101,7 +101,8 @@
 		"WebCommitSignoffRequired": { "type": ["boolean", "null"] },
 		"WikiEnabled": { "type": ["boolean", "null"] },
 		"RequireLastPushApproval": { "type": ["boolean", "null"] },
-		"RequireBranchesBeUpToDateBeforeMerging": { "type": ["boolean", "null"] }
+		"RequireBranchesBeUpToDateBeforeMerging": { "type": ["boolean", "null"] },
+		"SponsorshipsEnabled": { "type": ["boolean", "null"] }
 	},
 	"type": "object"
 }

--- a/src/getRepositories.js
+++ b/src/getRepositories.js
@@ -83,6 +83,7 @@ function generateQuery(endCursor, { f }, perPage = 20) {
 						viewerHasStarred
 						viewerPermission
 						viewerSubscription
+						hasSponsorshipsEnabled
 					}
 				}
 			}

--- a/test/fixtures/fixtures.js
+++ b/test/fixtures/fixtures.js
@@ -44,10 +44,12 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		'55.6% (5/9)',
 		'11.1% (1/9)',
 		'22.2% (2/9)',
+		'22.2% (2/9)',
 	],
 	[
 		'name/challenges-book\nname/responsive-design',
 		`${symbols.success}`,
+		`${symbols.error}`,
 		`${symbols.error}`,
 		`${symbols.error}`,
 		`${symbols.error}`,
@@ -62,6 +64,7 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		`${symbols.success}`,
 		`${symbols.error}`,
 		`${symbols.error}`,
+		`${symbols.error}`,
 	],
 	[
 		'name/ecma262',
@@ -70,6 +73,17 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		`${symbols.success}`,
 		`${symbols.error}`,
 		`${symbols.error}`,
+		`${symbols.error}`,
+		`${symbols.success}`,
+	],
+	[
+		'name/agendas',
+		`${symbols.success}`,
+		`${symbols.success}`,
+		`${symbols.error}`,
+		`${symbols.success}`,
+		`${symbols.error}`,
+		`${symbols.success}`,
 		`${symbols.error}`,
 	],
 	[
@@ -80,14 +94,6 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 		`${symbols.error}`,
 		`${symbols.success}`,
 		`${symbols.success}`,
-	],
-	[
-		'name/agendas',
-		`${symbols.success}`,
-		`${symbols.success}`,
-		`${symbols.error}`,
-		`${symbols.success}`,
-		`${symbols.error}`,
 		`${symbols.success}`,
 	],
 ], {
@@ -100,7 +106,9 @@ const tableOutput = Object.setPrototypeOf(Object.assign([
 			'SecurityPolicyEnabled',
 			'RequiredBranchProtectionSourcePercentage',
 			'RequireLastPushApproval',
-			'RequireBranchesBeUpToDateBeforeMerging'],
+			'RequireBranchesBeUpToDateBeforeMerging',
+			'SponsorshipsEnabled',
+		],
 	},
 }), Table.prototype);
 
@@ -114,6 +122,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'100',
 		'false',
 		'false',
+		'false',
 	],
 	[
 		'name/challenges-book',
@@ -122,6 +131,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'false',
 		'---',
 		'40',
+		'false',
 		'false',
 		'false',
 	],
@@ -134,6 +144,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'0',
 		'false',
 		'false',
+		'false',
 	],
 	[
 		'name/media-upload-app',
@@ -142,6 +153,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'false',
 		'---',
 		'100',
+		'false',
 		'false',
 		'false',
 	],
@@ -154,6 +166,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'60',
 		'true',
 		'true',
+		'true',
 	],
 	[
 		'name/ecma262',
@@ -164,6 +177,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'50',
 		'false',
 		'false',
+		'true',
 	],
 	[
 		'name/agendas',
@@ -174,6 +188,7 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 		'100',
 		'false',
 		'true',
+		'false',
 	],
 ], {
 	options: {
@@ -186,7 +201,9 @@ const tableOutputActual = Object.setPrototypeOf(Object.assign([
 			'CodeOfConduct',
 			'RequiredBranchProtectionSourcePercentage',
 			'RequireLastPushApproval',
-			'RequireBranchesBeUpToDateBeforeMerging'],
+			'RequireBranchesBeUpToDateBeforeMerging',
+			'SponsorshipsEnabled',
+		],
 	},
 }), Table.prototype);
 
@@ -200,6 +217,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.error} 40`,
 		`${symbols.error} false`,
 		`${symbols.error} false`,
+		`${symbols.error} false`,
 	],
 	[
 		'name/responsive-design',
@@ -208,6 +226,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.error} false`,
 		`${symbols.success} Contributor Covenant`,
 		`${symbols.error} 0`,
+		`${symbols.error} false`,
 		`${symbols.error} false`,
 		`${symbols.error} false`,
 	],
@@ -220,6 +239,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.success} 100`,
 		`${symbols.error} false`,
 		`${symbols.error} false`,
+		`${symbols.error} false`,
 	],
 	[
 		'name/media-upload-app',
@@ -228,6 +248,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.error} false`,
 		`${symbols.ignore} ---`,
 		`${symbols.success} 100`,
+		`${symbols.error} false`,
 		`${symbols.error} false`,
 		`${symbols.error} false`,
 	],
@@ -240,15 +261,6 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.error} 50`,
 		`${symbols.error} false`,
 		`${symbols.error} false`,
-	],
-	[
-		'name/tc39-ci',
-		`${symbols.success} ADMIN`,
-		`${symbols.success} main`,
-		`${symbols.error} false`,
-		`${symbols.ignore} ---`,
-		`${symbols.error} 60`,
-		`${symbols.success} true`,
 		`${symbols.success} true`,
 	],
 	[
@@ -259,6 +271,18 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 		`${symbols.ignore} ---`,
 		`${symbols.success} 100`,
 		`${symbols.error} false`,
+		`${symbols.success} true`,
+		`${symbols.error} false`,
+	],
+	[
+		'name/tc39-ci',
+		`${symbols.success} ADMIN`,
+		`${symbols.success} main`,
+		`${symbols.error} false`,
+		`${symbols.ignore} ---`,
+		`${symbols.error} 60`,
+		`${symbols.success} true`,
+		`${symbols.success} true`,
 		`${symbols.success} true`,
 	],
 ], {
@@ -273,6 +297,7 @@ const tableOutputActualGoodness = Object.setPrototypeOf(Object.assign([
 			'RequiredBranchProtectionSourcePercentage',
 			'RequireLastPushApproval',
 			'RequireBranchesBeUpToDateBeforeMerging',
+			'SponsorshipsEnabled',
 		],
 	},
 }), Table.prototype);
@@ -304,6 +329,7 @@ const DetailTableColumns = [
 	'ReqConversationResolution',
 	'RequireLastPushApproval',
 	'RequireBranchesBeUpToDateBeforeMerging',
+	'SponsorshipsEnabled',
 ];
 
 const sortedRepositories = require('./sortedRepositories.json');

--- a/test/fixtures/metricConfig.json
+++ b/test/fixtures/metricConfig.json
@@ -30,6 +30,7 @@
 		"ReqApprovingReviews": false,
 		"ReqCodeOwnerReviews": false,
 		"ReqConversationResolution": false,
-		"CodeOfConduct": [null, "Contributor Covenant"]
+		"CodeOfConduct": [null, "Contributor Covenant"],
+		"SponsorshipsEnabled": true
 	}
 }

--- a/test/fixtures/mockRepositoriesData.json
+++ b/test/fixtures/mockRepositoriesData.json
@@ -142,7 +142,8 @@
 							}
 						},
 						"viewerPermission": "ADMIN",
-						"isSecurityPolicyEnabled": false
+						"isSecurityPolicyEnabled": false,
+						"hasSponsorshipsEnabled": true
 					},
 					{
 						"name": "ecma262",
@@ -167,7 +168,8 @@
 							}
 						},
 						"viewerPermission": "ADMIN",
-						"isSecurityPolicyEnabled": true
+						"isSecurityPolicyEnabled": true,
+						"hasSponsorshipsEnabled": true
 					},
 					{
 						"name": "agendas",
@@ -182,7 +184,8 @@
 							"requiresStrictStatusChecks": true
 						}
 						},
-						"viewerPermission": "ADMIN"
+						"viewerPermission": "ADMIN",
+						"hasSponsorshipsEnabled": false
 
 					}
 				]

--- a/test/utils/generateDetailTable.js
+++ b/test/utils/generateDetailTable.js
@@ -15,7 +15,7 @@ const {
 
 const getMetrics = require('../../src/metrics');
 
-const metrics = getMetrics(['Repository', 'Access', 'DefBranch', 'isPrivate', 'SecurityPolicyEnabled', 'CodeOfConduct', 'RequiredBranchProtectionSourcePercentage', 'RequireLastPushApproval', 'RequireBranchesBeUpToDateBeforeMerging']);
+const metrics = getMetrics(['Repository', 'Access', 'DefBranch', 'isPrivate', 'SecurityPolicyEnabled', 'CodeOfConduct', 'RequiredBranchProtectionSourcePercentage', 'RequireLastPushApproval', 'RequireBranchesBeUpToDateBeforeMerging', 'SponsorshipsEnabled']);
 
 function compareTables(t, actual, expected, msg, invalid = false) {
 	const comparator = invalid ? 'notDeepEqual' : 'deepEqual';


### PR DESCRIPTION
Added metric: sponsorships enabled.

<img width="635" height="75" alt="image" src="https://github.com/user-attachments/assets/91afc8da-04b0-41ba-bbde-1cacb3f016d9" />


<img width="1683" height="843" alt="image" src="https://github.com/user-attachments/assets/1cd46d6d-ceb8-42dd-9097-e883b96b4ecd" />


Test passed.
<img width="997" height="742" alt="image" src="https://github.com/user-attachments/assets/199e6548-061a-4814-adc7-60dc01e3c801" />
